### PR TITLE
[feat] 플랜 공유 API 구현 및 공개 조회 기능 추가

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -16,6 +16,7 @@ import AuthLayout from '../components/layout/AuthLayout'
 
 import ProtectedRoute from '../routes/ProtectedRoute'
 import SocialCallbackPage from '@/features/auth/pages/SocialCallbackPage'
+import SharedPlanDetailPage from '@/features/plans/pages/SharedPlanDetailPage'
 
 export const router = createBrowserRouter([
   // 로그인 전 영역
@@ -25,8 +26,9 @@ export const router = createBrowserRouter([
       { path: '/', element: <HomePage /> },
       { path: '/login', element: <LoginPage /> },
       { path: '/signup', element: <SignupPage /> },
-      { path: '/auth/kakao/callback', element: <SocialCallbackPage provider='KAKAO' /> },
-      { path: '/auth/naver/callback', element: <SocialCallbackPage provider='NAVER' /> },
+      { path: '/auth/kakao/callback', element: <SocialCallbackPage provider="KAKAO" /> },
+      { path: '/auth/naver/callback', element: <SocialCallbackPage provider="NAVER" /> },
+      { path: '/shared/plans/:shareToken', element: <SharedPlanDetailPage /> },
     ],
   },
 

--- a/src/features/plans/api.ts
+++ b/src/features/plans/api.ts
@@ -112,6 +112,12 @@ export async function deletePlan(planId: number) {
   await http.delete(`/api/v1/plans/${planId}`)
 }
 
+// 플랜 공유 링크 생성 POST /api/v1/plans/{planId}/share
+export async function createPlanShareLink(planId: number): Promise<string> {
+  const res = await http.post(`/api/v1/plans/${planId}/share`)
+  return res.data.data
+}
+
 // 카테고리 타입 변경
 export async function updatePlanCategoryType(
   planId: number,

--- a/src/features/plans/api.ts
+++ b/src/features/plans/api.ts
@@ -1,5 +1,10 @@
 import { http } from '@/lib/http'
-import type { PlanListResponse, PlanCategorySummary, CandidateResponse } from './types'
+import type {
+  PlanListResponse,
+  PlanCategorySummary,
+  CandidateResponse,
+  SharedPlanDetailResponse,
+} from './types'
 
 // 플랜 목록 조회 GET /api/v1/plans
 export const fetchPlanSummaries = async (page = 0, size = 10): Promise<PlanListResponse> => {
@@ -119,9 +124,45 @@ export async function createPlanShareLink(planId: number): Promise<string> {
 }
 
 // 공유 플랜 상세 조회 GET /api/v1/plans/shared/{shareToken}
-export async function fetchSharedPlanDetail(shareToken: string) {
+export async function fetchSharedPlanDetail(shareToken: string): Promise<SharedPlanDetailResponse> {
   const res = await http.get(`/api/v1/plans/shared/${shareToken}`)
-  return res.data.data
+  const data = res.data.data
+
+  return {
+    plan: data.plan,
+
+    categories: (data.categories ?? []).map(
+      (c: {
+        planCategoryId: number
+        categoryType: string
+        sequence: number
+        representativeCandidateId: number
+        candidates?: CandidateResponse[]
+      }) => ({
+        id: c.planCategoryId,
+        type: c.categoryType,
+        order: c.sequence,
+        representativeCandidateId: c.representativeCandidateId,
+
+        candidates: (c.candidates ?? []).map((cd: CandidateResponse) => ({
+          id: cd.candidateId,
+
+          place: {
+            id: cd.place.id,
+            externalId: cd.place.externalId,
+            name: cd.place.name,
+            location: cd.place.address,
+            latitude: cd.place.latitude,
+            longitude: cd.place.longitude,
+            rating: 0,
+            isIndoor: cd.place.isIndoor ?? false,
+          },
+
+          isRepresentative: cd.isRepresentative ?? false,
+        })),
+      }),
+    ),
+  }
 }
 
 // 카테고리 타입 변경

--- a/src/features/plans/api.ts
+++ b/src/features/plans/api.ts
@@ -5,6 +5,7 @@ import type {
   CandidateResponse,
   SharedPlanDetailResponse,
 } from './types'
+import type { CategoryType } from '@/types/plan'
 
 // 플랜 목록 조회 GET /api/v1/plans
 export const fetchPlanSummaries = async (page = 0, size = 10): Promise<PlanListResponse> => {
@@ -140,7 +141,7 @@ export async function fetchSharedPlanDetail(shareToken: string): Promise<SharedP
         candidates?: CandidateResponse[]
       }) => ({
         id: c.planCategoryId,
-        type: c.categoryType,
+        type: c.categoryType as CategoryType,
         order: c.sequence,
         representativeCandidateId: c.representativeCandidateId,
 

--- a/src/features/plans/api.ts
+++ b/src/features/plans/api.ts
@@ -118,6 +118,12 @@ export async function createPlanShareLink(planId: number): Promise<string> {
   return res.data.data
 }
 
+// 공유 플랜 상세 조회 GET /api/v1/plans/shared/{shareToken}
+export async function fetchSharedPlanDetail(shareToken: string) {
+  const res = await http.get(`/api/v1/plans/shared/${shareToken}`)
+  return res.data.data
+}
+
 // 카테고리 타입 변경
 export async function updatePlanCategoryType(
   planId: number,

--- a/src/features/plans/components/CategoryCard.tsx
+++ b/src/features/plans/components/CategoryCard.tsx
@@ -16,6 +16,7 @@ interface CategoryCardProps {
   onSearch: () => void
   onDelete: () => void
   onDeleteCandidate: (candidateId: number) => void
+  readOnly?: boolean
 }
 
 export default function CategoryCard({
@@ -29,6 +30,7 @@ export default function CategoryCard({
   onSearch,
   onDelete,
   onDeleteCandidate,
+  readOnly = false,
 }: CategoryCardProps) {
   const { type, representativeCandidateId, candidates } = category
   const { label, Icon } = categoryMeta[type]
@@ -50,13 +52,15 @@ export default function CategoryCard({
           isExpanded ? 'bg-primary/5' : 'hover:bg-secondary/30',
         )}
       >
-        <div
-          {...dragHandleProps}
-          onClick={e => e.stopPropagation()}
-          className="flex h-8 w-8 items-center justify-center text-muted-foreground cursor-grab active:cursor-grabbing hover:text-foreground transition-colors"
-        >
-          <GripVertical className="h-4 w-4" />
-        </div>
+        {!readOnly && (
+          <div
+            {...dragHandleProps}
+            onClick={e => e.stopPropagation()}
+            className="flex h-8 w-8 items-center justify-center text-muted-foreground cursor-grab active:cursor-grabbing hover:text-foreground transition-colors"
+          >
+            <GripVertical className="h-4 w-4" />
+          </div>
+        )}
 
         <div className="flex h-11 w-11 items-center justify-center rounded-full bg-primary/10">
           <Icon className="h-5 w-5 text-primary" />
@@ -68,17 +72,19 @@ export default function CategoryCard({
         </div>
 
         <div className="flex items-center gap-2">
-          <button
-            type="button"
-            aria-label={`${label} 카테고리 삭제`}
-            onClick={e => {
-              e.stopPropagation()
-              onDelete()
-            }}
-            className="p-1 rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
-          >
-            <Trash2 className="h-4 w-4" />
-          </button>
+          {!readOnly && (
+            <button
+              type="button"
+              aria-label={`${label} 카테고리 삭제`}
+              onClick={e => {
+                e.stopPropagation()
+                onDelete()
+              }}
+              className="p-1 rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          )}
 
           <ChevronDown
             className={cn(
@@ -100,7 +106,7 @@ export default function CategoryCard({
             isRepresentative
             onSelect={() => {}}
             onDelete={() => onDeleteCandidate(representativeCandidate.id)}
-            canDelete={candidates.length > 1}
+            canDelete={!readOnly && candidates.length > 1}
           />
         ) : (
           <div className="rounded-xl border border-dashed border-border/50 bg-background/30 px-4 py-6 text-center text-sm text-muted-foreground">
@@ -108,19 +114,21 @@ export default function CategoryCard({
           </div>
         )}
 
-        <div className="mt-4">
-          <button
-            type="button"
-            onClick={e => {
-              e.stopPropagation()
-              onTrigger()
-            }}
-            className="flex h-11 w-full items-center justify-center gap-2 rounded-xl border border-primary/25 bg-primary/10 px-4 text-sm font-medium text-primary transition-colors hover:bg-primary/15"
-          >
-            <Zap className="h-4 w-4" />
-            트리거 발생
-          </button>
-        </div>
+        {!readOnly && (
+          <div className="mt-4">
+            <button
+              type="button"
+              onClick={e => {
+                e.stopPropagation()
+                onTrigger()
+              }}
+              className="flex h-11 w-full items-center justify-center gap-2 rounded-xl border border-primary/25 bg-primary/10 px-4 text-sm font-medium text-primary transition-colors hover:bg-primary/15"
+            >
+              <Zap className="h-4 w-4" />
+              트리거 발생
+            </button>
+          </div>
+        )}
       </div>
 
       {/* 후보 장소 목록 */}
@@ -128,17 +136,19 @@ export default function CategoryCard({
         <div className="border-t border-border/60 bg-secondary/15 px-5 py-4">
           <div className="mb-3 flex items-center justify-between">
             <p className="text-sm text-muted-foreground">후보 장소</p>
-            <button
-              type="button"
-              onClick={e => {
-                e.stopPropagation()
-                onSearch()
-              }}
-              className="flex items-center gap-1.5 text-sm text-primary hover:underline"
-            >
-              <Plus className="h-3.5 w-3.5" />
-              장소 추가
-            </button>
+            {!readOnly && (
+              <button
+                type="button"
+                onClick={e => {
+                  e.stopPropagation()
+                  onSearch()
+                }}
+                className="flex items-center gap-1.5 text-sm text-primary hover:underline"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                장소 추가
+              </button>
+            )}
           </div>
 
           {candidates.length > 0 ? (
@@ -148,9 +158,12 @@ export default function CategoryCard({
                   key={candidate.id}
                   place={candidate.place}
                   isRepresentative={candidate.id === representativeCandidateId}
-                  onSelect={() => onSelectRepresentative(candidate.id)}
+                  onSelect={() => {
+                    if (readOnly) return
+                    onSelectRepresentative(candidate.id)
+                  }}
                   onDelete={() => onDeleteCandidate(candidate.id)}
-                  canDelete={candidates.length > 1}
+                  canDelete={!readOnly && candidates.length > 1}
                 />
               ))}
             </div>

--- a/src/features/plans/pages/PlanDetailPage.tsx
+++ b/src/features/plans/pages/PlanDetailPage.tsx
@@ -313,8 +313,8 @@ export default function PlanDetailPage() {
       setShareLoading(true)
       setShareCopied(false)
 
-      const url = await createPlanShareLink(plan.id)
-      setShareLink(url)
+      const token = await createPlanShareLink(plan.id)
+      setShareLink(`${window.location.origin}/shared/plans/${token}`)
       setShareOpen(true)
     } catch (e) {
       console.error(e)

--- a/src/features/plans/pages/PlanDetailPage.tsx
+++ b/src/features/plans/pages/PlanDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom'
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Calendar, MapPin } from 'lucide-react'
+import { Calendar, MapPin, Share2, SquarePen, Trash2, Copy, X } from 'lucide-react'
 
 import CategoryCard from '../components/CategoryCard'
 import AddCategoryButton from '../components/AddCategoryButton'
@@ -11,7 +11,7 @@ import { formatKoreanDate } from '@/lib/date'
 
 import { setRepresentative } from '@/lib/api/place'
 import { createTrigger, createDecision, executeSwitch } from '@/lib/api/trigger'
-import { deletePlan, deletePlanCategory, deleteCandidate } from '../api'
+import { createPlanShareLink, deletePlan, deletePlanCategory, deleteCandidate } from '../api'
 import ConfirmDialog from '@/components/ui/ConfirmDialog'
 import type { Place, Category, CategoryType, TriggerType, Candidate } from '@/types/plan'
 import { createCategory } from '@/lib/api/category'
@@ -78,6 +78,11 @@ export default function PlanDetailPage() {
 
   const [deleteCategoryId, setDeleteCategoryId] = useState<number | null>(null)
   const [categoryDeleting, setCategoryDeleting] = useState(false)
+
+  const [shareOpen, setShareOpen] = useState(false)
+  const [shareLink, setShareLink] = useState('')
+  const [shareLoading, setShareLoading] = useState(false)
+  const [shareCopied, setShareCopied] = useState(false)
 
   const [deleteCandidateId, setDeleteCandidateId] = useState<number | null>(null)
   const [candidateDeleting, setCandidateDeleting] = useState(false)
@@ -301,6 +306,34 @@ export default function PlanDetailPage() {
     closePanel()
   }
 
+  const handleOpenShareModal = async () => {
+    if (!plan) return
+
+    try {
+      setShareLoading(true)
+      setShareCopied(false)
+
+      const url = await createPlanShareLink(plan.id)
+      setShareLink(url)
+      setShareOpen(true)
+    } catch (e) {
+      console.error(e)
+      alert('공유 링크 생성 실패')
+    } finally {
+      setShareLoading(false)
+    }
+  }
+
+  const handleCopyShareLink = async () => {
+    try {
+      await navigator.clipboard.writeText(shareLink)
+      setShareCopied(true)
+    } catch (e) {
+      console.error(e)
+      alert('링크 복사 실패')
+    }
+  }
+
   // SWITCH 확정
   const handleSwitchPlace = async (toCandidateId: number) => {
     if (!activeCategory) return
@@ -366,37 +399,40 @@ export default function PlanDetailPage() {
             {isManageOpen && (
               <>
                 <div className="fixed inset-0 z-40" onClick={() => setIsManageOpen(false)} />
-                <div className="absolute right-0 z-50 mt-2 w-40 rounded-xl border border-border bg-background p-1 shadow-lg">
+                <div className="absolute right-0 z-50 mt-2 w-44 rounded-xl border border-border bg-background p-1.5 shadow-lg">
                   <button
-                    className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-secondary"
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-sm transition-colors duration-200 hover:bg-secondary"
                     onClick={() => {
                       setIsManageOpen(false)
                       navigate(`/plans/${plan.id}/edit`)
                     }}
                   >
-                    ✏️ 수정
+                    <SquarePen className="h-4 w-4" />
+                    수정
                   </button>
 
                   <button
-                    className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-secondary"
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-sm transition-colors duration-200 hover:bg-secondary"
                     onClick={() => {
                       setIsManageOpen(false)
-                      console.log('공유')
+                      handleOpenShareModal()
                     }}
                   >
-                    🔗 공유
+                    <Share2 className="h-4 w-4" />
+                    {shareLoading ? '생성 중...' : '공유'}
                   </button>
 
                   <div className="my-1 h-px bg-border" />
 
                   <button
-                    className="flex w-full items-center gap-2 px-3 py-2 text-sm text-destructive hover:bg-destructive/10"
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-sm text-destructive transition-colors duration-200 hover:bg-destructive/10"
                     onClick={() => {
                       setIsManageOpen(false)
                       setDeleteOpen(true)
                     }}
                   >
-                    🗑️ 삭제
+                    <Trash2 className="h-4 w-4" />
+                    삭제
                   </button>
                 </div>
               </>
@@ -477,6 +513,63 @@ export default function PlanDetailPage() {
           onSwitchPlace={handleSwitchPlace}
           onChangeCategory={handleChangeCategory}
         />
+      )}
+
+      {shareOpen && (
+        <>
+          <div
+            className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[1px]"
+            onClick={() => setShareOpen(false)}
+          />
+
+          <div className="fixed inset-0 z-50 flex items-center justify-center px-6">
+            <div className="w-full max-w-md rounded-2xl border border-border bg-background p-6 shadow-2xl">
+              <div className="mb-4 flex items-start justify-between gap-4">
+                <div>
+                  <h2 className="text-lg font-semibold tracking-tight">공유 링크</h2>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    링크를 복사해 일정을 공유하세요.
+                  </p>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={() => setShareOpen(false)}
+                  className="rounded-md p-1 text-muted-foreground hover:bg-secondary"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+
+              <div className="rounded-xl border border-border bg-muted/40 px-4 py-3 text-sm break-all">
+                {shareLink}
+              </div>
+
+              <div className="mt-2 min-h-5 text-xs text-muted-foreground">
+                {shareCopied ? '링크가 복사되었습니다.' : ''}
+              </div>
+
+              <div className="mt-5 flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => setShareOpen(false)}
+                  className="rounded-lg border border-border px-4 py-2 text-sm transition-colors duration-200 hover:bg-secondary"
+                >
+                  닫기
+                </button>
+
+                <button
+                  type="button"
+                  onClick={handleCopyShareLink}
+                  className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-opacity duration-200 hover:opacity-90"
+                >
+                  <Copy className="h-4 w-4" />
+                  URL 복사
+                </button>
+              </div>
+            </div>
+          </div>
+        </>
       )}
 
       <ConfirmDialog

--- a/src/features/plans/pages/SharedPlanDetailPage.tsx
+++ b/src/features/plans/pages/SharedPlanDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
-import { Calendar, MapPin } from 'lucide-react'
+import { Calendar, MapPin, User } from 'lucide-react'
 import { formatKoreanDate } from '@/lib/date'
 import { fetchSharedPlanDetail } from '../api'
 import type { Category } from '@/types/plan'
@@ -11,6 +11,8 @@ type SharedPlan = {
   title: string
   date: string
   region: string
+  ownerNickname: string
+  ownerProfileImageUrl: string | null
 }
 
 export default function SharedPlanDetailPage() {
@@ -38,6 +40,8 @@ export default function SharedPlanDetailPage() {
           title: data.plan.title,
           date: data.plan.planDate,
           region: data.plan.region,
+          ownerNickname: data.plan.ownerNickname,
+          ownerProfileImageUrl: data.plan.ownerProfileImageUrl,
         })
 
         setCategories(
@@ -99,20 +103,44 @@ export default function SharedPlanDetailPage() {
   return (
     <div className="relative min-h-screen bg-background">
       <div className="mx-auto max-w-4xl px-6 py-10">
-        <header className="mb-8">
-          <div className="min-w-0">
-            <h1 className="break-words text-2xl font-semibold tracking-tight">{plan.title}</h1>
+        <header className="mb-8 overflow-hidden rounded-[28px] border border-border/60 bg-gradient-to-br from-primary/10 via-background to-secondary/40 shadow-[0_20px_60px_-30px_rgba(0,0,0,0.35)]">
+          <div className="px-6 py-6 sm:px-8 sm:py-8">
+            <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+              <div className="flex min-w-0 items-center gap-4">
+                {plan.ownerProfileImageUrl ? (
+                  <img
+                    src={plan.ownerProfileImageUrl}
+                    alt={`${plan.ownerNickname} 프로필 이미지`}
+                    className="h-16 w-16 shrink-0 rounded-full border border-white/70 object-cover shadow-md sm:h-20 sm:w-20"
+                  />
+                ) : (
+                  <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-primary/10 sm:h-20 sm:w-20">
+                    <User className="h-8 w-8 text-primary/60 sm:h-10 sm:w-10" aria-hidden="true" />
+                  </div>
+                )}
 
-            <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 text-sm text-muted-foreground">
-              <span className="flex items-center gap-1">
-                <Calendar className="h-4 w-4" />
-                {formatKoreanDate(plan.date)}
-              </span>
+                <div className="min-w-0">
+                  <p className="text-sm text-muted-foreground">
+                    <span className="font-semibold text-primary">{plan.ownerNickname}</span>
+                    <span className="ml-1">님의 플랜입니다</span>
+                  </p>
+                  <h1 className="mt-2 break-words text-2xl font-semibold tracking-tight sm:text-3xl">
+                    {plan.title}
+                  </h1>
 
-              <span className="flex items-center gap-1">
-                <MapPin className="h-4 w-4" />
-                {plan.region}
-              </span>
+                  <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 text-sm text-muted-foreground">
+                    <span className="flex items-center gap-1.5">
+                      <Calendar className="h-4 w-4" />
+                      {formatKoreanDate(plan.date)}
+                    </span>
+
+                    <span className="flex items-center gap-1.5">
+                      <MapPin className="h-4 w-4" />
+                      {plan.region}
+                    </span>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </header>
@@ -136,6 +164,30 @@ export default function SharedPlanDetailPage() {
               readOnly
             />
           ))}
+        </div>
+
+        <div className="mt-10 rounded-2xl border border-border/60 bg-gradient-to-br from-primary/10 to-background p-6 text-center shadow-sm">
+          <p className="text-sm text-muted-foreground">이 플랜이 마음에 드셨나요?</p>
+
+          <p className="mt-2 text-base font-medium text-foreground">
+            로그인하고 나만의 플랜을 만들어보세요
+          </p>
+
+          <div className="mt-5 flex justify-center gap-3">
+            <a
+              href="/login"
+              className="rounded-xl border border-border px-5 py-2 text-sm font-medium transition-colors duration-200 hover:bg-secondary"
+            >
+              로그인
+            </a>
+
+            <a
+              href="/signup"
+              className="rounded-xl bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground transition-colors duration-200 hover:opacity-90"
+            >
+              회원가입
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/src/features/plans/pages/SharedPlanDetailPage.tsx
+++ b/src/features/plans/pages/SharedPlanDetailPage.tsx
@@ -44,48 +44,7 @@ export default function SharedPlanDetailPage() {
           ownerProfileImageUrl: data.plan.ownerProfileImageUrl,
         })
 
-        setCategories(
-          (data.categories ?? []).map(
-            (c: {
-              planCategoryId: number
-              categoryType: string
-              sequence: number
-              representativeCandidateId: number
-              candidates?: Array<{
-                candidateId: number
-                isRepresentative?: boolean
-                place: {
-                  id: number
-                  externalId: string
-                  name: string
-                  address: string
-                  latitude: number
-                  longitude: number
-                  isIndoor?: boolean
-                }
-              }>
-            }) => ({
-              id: c.planCategoryId,
-              type: c.categoryType,
-              order: c.sequence,
-              representativeCandidateId: c.representativeCandidateId,
-              candidates: (c.candidates ?? []).map(cd => ({
-                id: cd.candidateId,
-                isRepresentative: cd.isRepresentative ?? false,
-                place: {
-                  id: cd.place.id,
-                  externalId: cd.place.externalId,
-                  name: cd.place.name,
-                  location: cd.place.address,
-                  latitude: cd.place.latitude,
-                  longitude: cd.place.longitude,
-                  rating: 0,
-                  isIndoor: cd.place.isIndoor ?? false,
-                },
-              })),
-            }),
-          ),
-        )
+        setCategories(data.categories)
       } catch (e) {
         console.error(e)
         setError('공유된 플랜 정보를 불러오지 못했습니다.')

--- a/src/features/plans/pages/SharedPlanDetailPage.tsx
+++ b/src/features/plans/pages/SharedPlanDetailPage.tsx
@@ -1,0 +1,142 @@
+import { useParams } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { Calendar, MapPin } from 'lucide-react'
+import { formatKoreanDate } from '@/lib/date'
+import { fetchSharedPlanDetail } from '../api'
+import type { Category } from '@/types/plan'
+import CategoryCard from '../components/CategoryCard'
+
+type SharedPlan = {
+  id: number
+  title: string
+  date: string
+  region: string
+}
+
+export default function SharedPlanDetailPage() {
+  const { shareToken } = useParams<{ shareToken: string }>()
+
+  const [plan, setPlan] = useState<SharedPlan | null>(null)
+  const [categories, setCategories] = useState<Category[]>([])
+  const [expandedCategoryId, setExpandedCategoryId] = useState<number | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const run = async () => {
+      if (!shareToken) {
+        setError('잘못된 접근입니다.')
+        setLoading(false)
+        return
+      }
+
+      try {
+        const data = await fetchSharedPlanDetail(shareToken)
+
+        setPlan({
+          id: data.plan.planId,
+          title: data.plan.title,
+          date: data.plan.planDate,
+          region: data.plan.region,
+        })
+
+        setCategories(
+          (data.categories ?? []).map(
+            (c: {
+              planCategoryId: number
+              categoryType: string
+              sequence: number
+              representativeCandidateId: number
+              candidates?: Array<{
+                candidateId: number
+                isRepresentative?: boolean
+                place: {
+                  id: number
+                  externalId: string
+                  name: string
+                  address: string
+                  latitude: number
+                  longitude: number
+                  isIndoor?: boolean
+                }
+              }>
+            }) => ({
+              id: c.planCategoryId,
+              type: c.categoryType,
+              order: c.sequence,
+              representativeCandidateId: c.representativeCandidateId,
+              candidates: (c.candidates ?? []).map(cd => ({
+                id: cd.candidateId,
+                isRepresentative: cd.isRepresentative ?? false,
+                place: {
+                  id: cd.place.id,
+                  externalId: cd.place.externalId,
+                  name: cd.place.name,
+                  location: cd.place.address,
+                  latitude: cd.place.latitude,
+                  longitude: cd.place.longitude,
+                  rating: 0,
+                  isIndoor: cd.place.isIndoor ?? false,
+                },
+              })),
+            }),
+          ),
+        )
+      } catch (e) {
+        console.error(e)
+        setError('공유된 플랜 정보를 불러오지 못했습니다.')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    run()
+  }, [shareToken])
+
+  if (loading) return <div className="p-10">불러오는 중...</div>
+  if (error || !plan) return <div className="p-10">{error ?? '잘못된 접근입니다.'}</div>
+
+  return (
+    <div className="relative min-h-screen bg-background">
+      <div className="mx-auto max-w-4xl px-6 py-10">
+        <header className="mb-8">
+          <div className="min-w-0">
+            <h1 className="break-words text-2xl font-semibold tracking-tight">{plan.title}</h1>
+
+            <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 text-sm text-muted-foreground">
+              <span className="flex items-center gap-1">
+                <Calendar className="h-4 w-4" />
+                {formatKoreanDate(plan.date)}
+              </span>
+
+              <span className="flex items-center gap-1">
+                <MapPin className="h-4 w-4" />
+                {plan.region}
+              </span>
+            </div>
+          </div>
+        </header>
+
+        <div className="space-y-8">
+          {categories.map(category => (
+            <CategoryCard
+              key={category.id}
+              category={category}
+              isExpanded={expandedCategoryId === category.id}
+              isDragging={false}
+              dragHandleProps={undefined}
+              onToggle={() =>
+                setExpandedCategoryId(prev => (prev === category.id ? null : category.id))
+              }
+              onSelectRepresentative={() => {}}
+              onSearch={() => {}}
+              onTrigger={() => {}}
+              onDelete={() => {}}
+              onDeleteCandidate={() => {}}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/plans/pages/SharedPlanDetailPage.tsx
+++ b/src/features/plans/pages/SharedPlanDetailPage.tsx
@@ -133,6 +133,7 @@ export default function SharedPlanDetailPage() {
               onTrigger={() => {}}
               onDelete={() => {}}
               onDeleteCandidate={() => {}}
+              readOnly
             />
           ))}
         </div>

--- a/src/features/plans/types.ts
+++ b/src/features/plans/types.ts
@@ -105,7 +105,7 @@ export type SharedPlanDetailResponse = {
   }
   categories: Array<{
     id: number
-    type: string
+    type: CategoryType
     order: number
     representativeCandidateId: number
     candidates: Array<{

--- a/src/features/plans/types.ts
+++ b/src/features/plans/types.ts
@@ -90,3 +90,37 @@ export interface PlanDetailCandidateDto {
   }
   isRepresentative: boolean
 }
+
+export type SharedPlanDetailResponse = {
+  plan: {
+    planId: number
+    title: string
+    planDate: string
+    region: string
+    status: string
+    ownerNickname: string
+    ownerProfileImageUrl: string | null
+    createdAt: string
+    updatedAt: string
+  }
+  categories: Array<{
+    id: number
+    type: string
+    order: number
+    representativeCandidateId: number
+    candidates: Array<{
+      id: number
+      place: {
+        id: number
+        externalId: string
+        name: string
+        location: string
+        latitude: number
+        longitude: number
+        rating: number
+        isIndoor: boolean
+      }
+      isRepresentative: boolean
+    }>
+  }>
+}

--- a/src/features/plans/types.ts
+++ b/src/features/plans/types.ts
@@ -112,7 +112,7 @@ export type SharedPlanDetailResponse = {
       id: number
       place: {
         id: number
-        externalId: string
+        externalId?: string
         name: string
         location: string
         latitude: number

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#60 

## 📝 작업 내용

- 플랜 공유 기능 구현
  - 공유 링크 생성 API 연동
- 공유 플랜 상세 페이지 구현
  - 비로그인 사용자 접근 가능
  - 기존 상세 페이지와 분리하여 read only 구조 구현
- 작성자 정보 표시

## 🖼️ 스크린샷 (선택)
### 관리 버튼 선택
<img width="1065" height="315" alt="image" src="https://github.com/user-attachments/assets/b9080193-3574-4bcf-98b3-8b96c5ff9dde" />

- 아이콘 수정됨


### 공유 URL 복사
<img width="1008" height="469" alt="image" src="https://github.com/user-attachments/assets/aadc36b0-290c-470a-bd6d-c23e2fb4499f" />


### 공유된 플랜
<img width="1223" height="1202" alt="image" src="https://github.com/user-attachments/assets/0de49b51-78db-4e02-9674-34ab688561d1" />

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 계획을 고유 공유 링크로 생성·복사할 수 있는 공유 모달 추가
  * 공유 링크로 로그인 없이 조회 가능한 읽기 전용 계획 페이지 추가 (카테고리·후보 항목 확장/축소 가능, 로그인/회원가입 CTA 포함)

* **개선**
  * 공유 모달에 생성 로딩 및 복사 성공 표시 추가
  * 읽기 전용 모드로 편집·삭제 UI가 비활성화되어 무단 편집 방지
<!-- end of auto-generated comment: release notes by coderabbit.ai -->